### PR TITLE
Fix documentation to use hyperlink.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,8 @@ One and only one of these features must be set somewhere in the cargo dependency
 graph in order for the cuda crate to be used, otherwise the crate will force a
 compile-time error.
 
-For further details on CUDA version compatibility, please see:
-https://docs.nvidia.com/deploy/cuda-compatibility/index.html.
+For further details on CUDA version compatibility, please see
+[the CUDA compatibility guide.](https://docs.nvidia.com/deploy/cuda-compatibility/index.html)
 
 ### Recommendations
 


### PR DESCRIPTION
Hello,

This changes a link from plain text into a click-able hyperlink.

I'd also like to improve the documentation on this project.  It would be nice if the FFI module's documentation linked to nvidia's online documentation [*]. Currently that code is not at all documented.

Would it be okay to added these links?

[*] https://docs.nvidia.com/cuda/
https://docs.nvidia.com/cuda/cuda-driver-api/index.html
https://docs.nvidia.com/cuda/cuda-runtime-api/index.html