### PR TITLE
FFI: add documentation links.

### DIFF
--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,3 +1,18 @@
+/*! Foreign Function Interface for CUDA libraries.
+
+Official Documentation links:
+- [Index of CUDA Toolkit Documentation](https://docs.nvidia.com/cuda/index.html)
+- [cuBLAS: The CUDA Basic Linear Algebra Subroutine library API reference guide.
+            ](https://docs.nvidia.com/cuda/cublas/index.html)
+- [CUDA Driver API reference guide.
+            ](https://docs.nvidia.com/cuda/cuda-driver-api/index.html)
+- [Math & fp16 reference guide.
+            ](https://docs.nvidia.com/cuda/cuda-math-api/index.html)
+- [Runtime API reference guide.
+            ](https://docs.nvidia.com/cuda/cuda-runtime-api/index.html)
+- [cuRAND: The CUDA random number generation library API reference guide.
+            ](https://docs.nvidia.com/cuda/curand/index.html)
+*/
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]


### PR DESCRIPTION
I improved the documentation for the FFI module.

Because of the way this is structured internally, it's difficulty to apply documentation to the individual CUDA library wrappers, so instead I put all of the links in the FFI module.